### PR TITLE
Update install to include upstream dependencies

### DIFF
--- a/src/doc/install.html
+++ b/src/doc/install.html
@@ -9,7 +9,7 @@
 Ubuntu comes with Python but we need to install pip, python-dev and several libraries.  This was tested on a fully patched installation of Ubuntu 14.04.
 
 <pre class="terminal">
-$ sudo apt-get install python-pip python-dev libffi-dev libssl-dev libxml2-dev libxslt1-dev
+$ sudo apt-get install python-pip python-dev libffi-dev libssl-dev libxml2-dev libxslt1-dev libjpeg8-dev zlib1g-dev
 
 $ sudo pip install mitmproxy
 </pre>


### PR DESCRIPTION
Pillow depends upon libjpeg8-dev and zlib1g-dev. Documentation in main repo reflects this as of 4537d561c680ef162d23487251c4c41b797f0723, website should be updated accordingly. Not totally sure if this is the appropriate place for the update, though (static site generator?).